### PR TITLE
setupTests.js: include working teardown example

### DIFF
--- a/e2e/setupTests.js
+++ b/e2e/setupTests.js
@@ -1,3 +1,14 @@
+import { driver } from './helpers';
+
+// Tear down chrome Driver when tests
+// are concluded.
+
+afterAll((done) => {
+  driver.quit().then(() => done());
+});
+
+// set defaults
+
 process.env.USE_PROMISE_MANAGER = false;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60e3;


### PR DESCRIPTION
this adds a teardown option to the `setupTests.js`

Without this, the chrome instances that spawn are simply left hanging open after `jest` exits.